### PR TITLE
use :extraPlugins instruction instead of :plugins

### DIFF
--- a/docs/features/markdown.md
+++ b/docs/features/markdown.md
@@ -50,14 +50,7 @@ function Markdown( editor ) {
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-markdown' ), {
-		plugins: [
-			Markdown,
-
-			Essentials,
-			Bold,
-			Italic,
-			// ...
-		],
+		extraPlugins: [ Markdown ],
 		// ...
 	} )
 	.then( ... )


### PR DESCRIPTION
Replaces plugins: by extraPlugins: in configuration

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Type: Message. Closes #000.

---

### Additional information

Could not apply the Markdown plugin without using the :extraPlugins declaration instead of :plugins
